### PR TITLE
fix: add calls to `extism_function_free` to cleanup HostFunctions

### DIFF
--- a/src/main/java/org/extism/sdk/HostFunction.java
+++ b/src/main/java/org/extism/sdk/HostFunction.java
@@ -10,6 +10,8 @@ public class HostFunction<T extends HostUserData> {
 
     private final LibExtism.InternalExtismFunction callback;
 
+    private boolean freed;
+
     public final Pointer pointer;
 
     public final String name;
@@ -21,7 +23,7 @@ public class HostFunction<T extends HostUserData> {
     public final Optional<T> userData;
 
     public HostFunction(String name, LibExtism.ExtismValType[] params, LibExtism.ExtismValType[] returns, ExtismFunction f, Optional<T> userData) {
-
+        this.freed = false;
         this.name = name;
         this.params = params;
         this.returns = returns;
@@ -85,8 +87,15 @@ public class HostFunction<T extends HostUserData> {
         }
     }
 
-    HostFunction withNamespace(String name) {
+    public HostFunction withNamespace(String name) {
         this.setNamespace(name);
         return this;
+    }
+
+    public void free() {
+        if (!this.freed){
+            LibExtism.INSTANCE.extism_function_free(this.pointer);
+            this.freed = true;
+        }
     }
 }

--- a/src/main/java/org/extism/sdk/LibExtism.java
+++ b/src/main/java/org/extism/sdk/LibExtism.java
@@ -62,6 +62,8 @@ public interface LibExtism extends Library {
                                 Pointer userData,
                                 Pointer freeUserData);
 
+    void extism_function_free(Pointer function);
+
     /**
      * Get the length of an allocated block
      * NOTE: this should only be called from host functions.

--- a/src/main/java/org/extism/sdk/Plugin.java
+++ b/src/main/java/org/extism/sdk/Plugin.java
@@ -42,6 +42,10 @@ public class Plugin implements AutoCloseable {
                 withWASI,
                 errormsg);
         if (p == null) {
+            if (functions != null)
+                for (int i = 0; i < functions.length; i++) {
+                   LibExtism.INSTANCE.extism_function_free(functions[i].pointer);
+                }
             int errlen = LibExtism.INSTANCE.strlen(errormsg[0]);
             byte[] msg = new byte[errlen];
             errormsg[0].read(0, msg, 0, errlen);

--- a/src/main/java/org/extism/sdk/Plugin.java
+++ b/src/main/java/org/extism/sdk/Plugin.java
@@ -17,6 +17,8 @@ public class Plugin implements AutoCloseable {
      */
     private final Pointer pluginPointer;
 
+    private final HostFunction[] functions;
+
     /**
      * @param manifestBytes The manifest for the plugin
      * @param functions     The Host functions for th eplugin
@@ -47,6 +49,7 @@ public class Plugin implements AutoCloseable {
             throw new ExtismException(new String(msg));
         }
 
+        this.functions = functions;
         this.pluginPointer = p;
     }
 
@@ -114,6 +117,11 @@ public class Plugin implements AutoCloseable {
      * Frees a plugin from memory
      */
     public void free() {
+        if (this.functions != null){
+            for (int i = 0; i < this.functions.length; i++) {
+                this.functions[i].free();
+            }
+        }
         LibExtism.INSTANCE.extism_plugin_free(this.pluginPointer);
     }
 

--- a/src/test/java/org/extism/sdk/PluginTests.java
+++ b/src/test/java/org/extism/sdk/PluginTests.java
@@ -195,6 +195,8 @@ public class PluginTests {
             var output = plugin.call(functionName, "this is a test");
             assertThat(output).isEqualTo("test");
         }
+
+        helloWorld.free();
     }
 
     @Test
@@ -242,6 +244,9 @@ public class PluginTests {
             var output = plugin.call(functionName, "this is a test");
             assertThat(output).isEqualTo("test");
         }
+
+        f.free();
+        g.free();
     }
 
 

--- a/src/test/java/org/extism/sdk/PluginTests.java
+++ b/src/test/java/org/extism/sdk/PluginTests.java
@@ -195,8 +195,6 @@ public class PluginTests {
             var output = plugin.call(functionName, "this is a test");
             assertThat(output).isEqualTo("test");
         }
-
-        helloWorld.free();
     }
 
     @Test
@@ -244,9 +242,6 @@ public class PluginTests {
             var output = plugin.call(functionName, "this is a test");
             assertThat(output).isEqualTo("test");
         }
-
-        f.free();
-        g.free();
     }
 
 


### PR DESCRIPTION
It looks like there isn't a good way to define a destructor in Java, so this PR adds a `HostFunction.free` function that is automatically called when a Plugin is freed, if a `HostFunction` is never registered with a plugin then it should be called manually.

Fixes #13 