### PR TITLE
Add script to pull extism libraries and maven plugin to include them in jar

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - uses: ./.github/actions/libextism
+      - name: fetch-extism-librairies
+        run: sh ./update-extism.sh
       - name: Set up Java
         uses: actions/setup-java@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
   <build>
     <plugins>
       <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>

--- a/update-extism.sh
+++ b/update-extism.sh
@@ -1,0 +1,34 @@
+EXTISM_VERSION=$(curl https://api.github.com/repos/extism/extism/releases/latest | jq -r '.name')
+
+echo "latest extism version is: ${EXTISM_VERSION}"
+
+rm -rf src/main/resources
+mkdir -p ./src/main/resources/natives/
+
+create_librairies_folders() {
+  declare -a archs=("darwin-aarch64" "darwin-x86-64" "linux-aarch64" "linux-x86-64" "win32-x86-64")
+  for i in "${archs[@]}"
+  do
+     mkdir ./src/main/resources/$i
+  done
+}
+
+fetch_and_unzip_library() {
+  local ARCH="$1"
+  local LIBRARY_FOLDER="$2"
+  local FILENAME="$3"
+
+  curl -L -o "./src/main/resources/natives/${ARCH}-${EXTISM_VERSION}.tar.gz" "https://github.com/extism/extism/releases/download/${EXTISM_VERSION}/${ARCH}-${EXTISM_VERSION}.tar.gz"
+  tar -xvf "./src/main/resources/natives/${ARCH}-${EXTISM_VERSION}.tar.gz" --directory ./src/main/resources/natives/
+  mv ./src/main/resources/natives/${FILENAME} ./src/main/resources/${LIBRARY_FOLDER}/${FILENAME}
+}
+
+create_librairies_folders
+
+fetch_and_unzip_library "libextism-aarch64-apple-darwin" "darwin-aarch64" "libextism.dylib"
+fetch_and_unzip_library "libextism-x86_64-apple-darwin" "darwin-x86-64" "libextism.dylib"
+fetch_and_unzip_library "libextism-aarch64-unknown-linux-gnu" "linux-aarch64" "libextism.so"
+fetch_and_unzip_library "libextism-x86_64-unknown-linux-gnu" "linux-x86-64" "libextism.so"
+fetch_and_unzip_library "libextism-x86_64-pc-windows-gnu" "win32-x86-64" "extism.dll"
+
+rm -rf src/main/resources/natives 2> /dev/null


### PR DESCRIPTION
Hi,

I have used this method in other projects. It's really simple but effective. Before bundling the java-sdk, I run a script to fetch and include libextism in the resources folder. In the resources folder, we have every processor architecture. 

When the java-sdk jar is included, the right libextism library is loaded.

<img width="224" alt="Screenshot 2024-02-09 at 16 42 51" src="https://github.com/extism/java-sdk/assets/6641669/752b39ac-ae12-4ef9-9bea-288aa5ff8cf9">

<img width="680" alt="Screenshot 2024-02-09 at 16 43 19" src="https://github.com/extism/java-sdk/assets/6641669/76de9a9c-8216-4518-9fc9-0071eac18240">

<img width="678" alt="Screenshot 2024-02-09 at 16 43 28" src="https://github.com/extism/java-sdk/assets/6641669/a39f8b33-f667-42ae-bf70-283a95fded34">
